### PR TITLE
Add force refresh after write operations

### DIFF
--- a/notekit.m
+++ b/notekit.m
@@ -77,6 +77,13 @@ static void printJSON(id obj) {
     printf("%s\n", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding].UTF8String);
 }
 
+static void triggerNotesRefresh(void) {
+    // Only activate Notes.app if it's already running to force UI refresh
+    NSAppleScript *script = [[NSAppleScript alloc] initWithSource:
+        @"if application \"Notes\" is running then tell application \"Notes\" to activate"];
+    [script executeAndReturnError:nil];
+}
+
 // --- Fetch Helpers ---
 
 static NSArray *fetchFolders(id viewContext) {
@@ -378,6 +385,7 @@ static int cmdCreateFolder(id viewContext, NSString *name) {
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"name": name, @"created": @YES});
     return 0;
@@ -398,6 +406,7 @@ static int cmdDeleteFolder(id viewContext, NSString *name) {
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"name": name, @"deleted": @YES});
     return 0;
@@ -488,6 +497,7 @@ static int cmdDuplicate(id viewContext, NSString *identifier, NSString *newTitle
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(noteToDict(newNote));
     return 0;
@@ -633,6 +643,7 @@ static int cmdSetAttr(id viewContext, NSString *identifier,
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"id": identifier, @"offset": @(offset), @"length": @(length), @"updated": @YES});
     return 0;
@@ -654,6 +665,7 @@ static int cmdMoveNote(id viewContext, NSString *identifier, NSString *toFolder)
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"id": identifier, @"movedTo": toFolder});
     return 0;
@@ -688,6 +700,7 @@ static int cmdPin(id viewContext, NSString *identifier, BOOL pin) {
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"id": identifier, @"pinned": @(pin)});
     return 0;
@@ -916,6 +929,7 @@ static int cmdCreateEmpty(id viewContext, NSString *folderName) {
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(noteToDict(note));
     return 0;
@@ -931,6 +945,7 @@ static int cmdDelete(id viewContext, NSString *identifier) {
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 
     printJSON(@{@"id": identifier, @"deleted": @YES});
     return 0;
@@ -946,6 +961,7 @@ static void saveNote(id note, id viewContext, NSUInteger newLength, NSInteger de
     NSError *error = nil;
     [viewContext save:&error];
     if (error) errorExit([NSString stringWithFormat:@"Save error: %@", error]);
+    triggerNotesRefresh();
 }
 
 static int cmdAppend(id viewContext, NSString *identifier, NSString *text, NSInteger styleValue) {
@@ -2139,6 +2155,7 @@ static int cmdWriteMarkdownWithString(id note, id viewContext, NSString *markdow
     if (error) {
         errorExit([NSString stringWithFormat:@"Save error: %@", error]);
     }
+    triggerNotesRefresh();
 
     printJSON(summary);
     return 0;


### PR DESCRIPTION
## Summary

- After any write operation, triggers Notes.app UI refresh via AppleScript `activate`
- Only activates if Notes.app is already running (no-op otherwise)
- Covers all write commands: append, insert, delete-range, replace, delete-line, write-markdown, set-attr, move, pin/unpin, create/delete folder, create-empty, duplicate, delete

## Implementation

Added a `triggerNotesRefresh()` helper that uses AppleScript to conditionally activate Notes.app. Called after every successful Core Data save in write command paths, including both the `saveNote()` helper (used by append, insert, delete-range, replace, delete-line) and individual command functions.

## Test plan

- [x] All 70 existing tests pass
- [x] Manual verification: append text with Notes.app open, confirm UI updates
- [ ] Verify no activation occurs when Notes.app is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)