### PR TITLE
Update pre-push hook to verify generator sync

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,25 @@
 #!/bin/bash
-# Pre-push hook: verify notekit.m compiles and tests pass.
-# notekit.m is maintained manually (no longer auto-generated).
+# Pre-push hook: ensure notekit.m is up to date with the generator.
+# Runs `make generate` and fails the push if notekit.m has uncommitted changes.
 
 set -e
 
-echo "Building notekit..."
-if ! make notekit; then
+echo "Running make generate to check for drift..."
+
+if ! make generate; then
     echo ""
-    echo "ERROR: notekit.m failed to compile. Fix before pushing."
+    echo "ERROR: 'make generate' failed. Fix the issue before pushing."
     exit 1
 fi
 
-echo "Build succeeded."
+# Check if notekit.m has uncommitted changes
+if ! git diff --quiet -- notekit.m; then
+    echo ""
+    echo "ERROR: notekit.m has uncommitted changes after running 'make generate'."
+    echo "The generator output is out of sync with the committed file."
+    echo ""
+    echo "To fix: commit the regenerated notekit.m, then push again."
+    exit 1
+fi
+
+echo "Generator and runtime are in sync."


### PR DESCRIPTION
## Summary
- Replace the build-only pre-push hook with one that runs `make generate` and fails if `notekit.m` has uncommitted changes afterward
- Matches the pattern used in reminderkit-cli to ensure the generator and committed runtime stay in sync

## Note
The generator (`generate-notes-cli.py`) currently produces different output from the committed `notekit.m` (which has been manually maintained with additional features). This means the hook will correctly block pushes until the generator is updated to match the committed file. This is intentional — the hook catches real drift.

## Test plan
- [ ] Run `make install-hooks` to activate the hook
- [ ] Verify `git push` fails when `notekit.m` differs from generator output
- [ ] Verify `git push` succeeds when generator output matches committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)