### PR TITLE
fix: filter out soft-deleted folders and notes

### DIFF
--- a/generate-notes-cli.py
+++ b/generate-notes-cli.py
@@ -497,6 +497,7 @@ static int cmdMoveNote(id viewContext, NSString *title, NSString *fromFolder, NS
 static int cmdSearch(id viewContext, NSString *query, NSString *folderName) {
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"ICNote"];
     NSMutableArray *predicates = [NSMutableArray array];
+    [predicates addObject:activeNotePredicate()];
     [predicates addObject:[NSPredicate predicateWithFormat:@"title CONTAINS[cd] %@ OR snippet CONTAINS[cd] %@", query, query]];
     if (folderName) {
         [predicates addObject:[NSPredicate predicateWithFormat:@"folder.title == %@", folderName]];

--- a/notekit.m
+++ b/notekit.m
@@ -757,6 +757,7 @@ static int cmdMoveNote(id viewContext, NSString *identifier, NSString *toFolder)
 static int cmdSearch(id viewContext, NSString *query, NSString *folderName) {
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"ICNote"];
     NSMutableArray *predicates = [NSMutableArray array];
+    [predicates addObject:activeNotePredicate()];
     [predicates addObject:[NSPredicate predicateWithFormat:@"title CONTAINS[cd] %@ OR snippet CONTAINS[cd] %@", query, query]];
     if (folderName) {
         [predicates addObject:[NSPredicate predicateWithFormat:@"folder.title == %@", folderName]];
@@ -1424,7 +1425,10 @@ static NSArray *noteToParaModel(id note) {
             NSString *linkURL = nil;
             if (viewContext) {
                 NSFetchRequest *req = [[NSFetchRequest alloc] initWithEntityName:@"ICNote"];
-                req.predicate = [NSPredicate predicateWithFormat:@"title == %@", displayText];
+                req.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+                    activeNotePredicate(),
+                    [NSPredicate predicateWithFormat:@"title == %@", displayText]
+                ]];
                 req.fetchLimit = 1;
                 NSArray *results = [viewContext executeFetchRequest:req error:nil];
                 if (results.count > 0) {


### PR DESCRIPTION
## Summary
- Filter soft-deleted folders and notes from all Core Data query paths
- `fetchFolders` was returning folders from "Recently Deleted" because it had no `markedForDeletion` predicate
- Centralized predicate helpers (`activeFolderPredicate`, `activeNotePredicate`) applied to all 6 fetch paths
- `activeNotePredicate` also checks `folder.markedForDeletion == NO` to exclude notes whose parent folder is deleted

## Test plan
- [x] Build compiles cleanly
- [x] All 84 existing tests pass
- [x] `notekit folders` no longer shows Recently Deleted or soft-deleted folders
- [x] Codex static analysis review: approved (all fetch paths covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)