### PR TITLE
fix: convert U+2028 back to \n when writing paragraphs

### DIFF
--- a/notekit.m
+++ b/notekit.m
@@ -2112,8 +2112,10 @@ static NSArray *markdownToParaModel(NSString *markdown) {
             }
         }
 
-        // Convert <br> to U+2028 (soft line break) for write round-trip fidelity
+        // Convert <br> variants to U+2028 (soft line break) for write round-trip fidelity
         if (textContent) {
+            textContent = [textContent stringByReplacingOccurrencesOfString:@"<br />" withString:@"\u2028"];
+            textContent = [textContent stringByReplacingOccurrencesOfString:@"<br/>" withString:@"\u2028"];
             textContent = [textContent stringByReplacingOccurrencesOfString:@"<br>" withString:@"\u2028"];
         }
 
@@ -2232,6 +2234,12 @@ static NSArray *computeParaOffsets(id note) {
     }
 
     return offsets;
+}
+
+// Convert para model text (which uses U+2028 for soft line breaks) to Apple Notes
+// storage format (which uses \n within a single attribute range).
+static NSString *storageTextForPara(NSString *text) {
+    return [text stringByReplacingOccurrencesOfString:@"\u2028" withString:@"\n"];
 }
 
 static int cmdWriteMarkdownWithString(id note, id viewContext, NSString *markdown, BOOL dryRun, BOOL backup) {
@@ -2491,10 +2499,11 @@ static int cmdWriteMarkdownWithString(id note, id viewContext, NSString *markdow
             NSString *oldText = oldPara[@"text"];
 
             if (![normalizeParaText(oldText) isEqualToString:normalizeParaText(newText)]) {
+                NSString *writeText = storageTextForPara(newText);
                 ((void (*)(id, SEL, NSRange))objc_msgSend)(ms, sel_registerName("deleteCharactersInRange:"),
                     NSMakeRange(pos, paraLen));
                 ((void (*)(id, SEL, id, NSUInteger))objc_msgSend)(ms, sel_registerName("insertString:atIndex:"),
-                    newText, pos);
+                    writeText, pos);
                 cumulativeDelta += (NSInteger)newText.length - (NSInteger)paraLen;
                 paraLen = newText.length;
             }
@@ -2610,7 +2619,7 @@ static int cmdWriteMarkdownWithString(id note, id viewContext, NSString *markdow
         }
         else if ([opType isEqualToString:@"insert"]) {
             NSDictionary *newPara = op[@"newPara"];
-            NSString *newText = newPara[@"text"];
+            NSString *newText = storageTextForPara(newPara[@"text"]);
             NSString *toInsert = [NSString stringWithFormat:@"%@\n", newText];
 
             NSUInteger currentMsLenForInsert = (NSUInteger)((NSInteger)msLen + cumulativeDelta);


### PR DESCRIPTION
## Summary
- Converts U+2028 (line separator) back to `\n` when writing paragraph text to Apple Notes
- The para model uses U+2028 internally for soft line breaks within paragraphs, but Apple Notes stores them as `\n` within a single attribute range
- Without this conversion, `<br>` tags in markdown round-trip to U+2028 which gets lost, causing line breaks to become spaces

## Changes
- **Modify path**: Creates `writeText` with U+2028→`\n` conversion before inserting into mergeableString
- **Insert path**: Converts `newText` U+2028→`\n` before building the insert string

## Test plan
- [x] Simple `<br>` round-trip: `Line 1<br>Line 2<br>Line 3` → stored as `\n` → reads back with `<br>` tags
- [x] Full Square TODO note round-trip: 153 paragraphs original == 153 round-trip
- [x] Raw attrs verification: stored characters are `\n` (U+000A) not U+2028
- [x] Idempotency: re-writing same content produces 0 modifications for `<br>` paragraphs
- [x] Builds clean with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)