### PR TITLE
Add issue-reporting instructions to CLI help

### DIFF
--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2007,6 +2007,9 @@ static void usage(void) {
     fprintf(stderr, "\n");
     fprintf(stderr, "Testing:\n");
     fprintf(stderr, "  notekit test\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Report issues:\n");
+    fprintf(stderr, "  gh api repos/johnmatthewtennant/notekit-cli/issues --method POST -f title=\"...\" -f body=\"...\"\n");
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a "Report issues" section to the CLI help/usage output
- Shows users how to file GitHub issues using `gh api repos/johnmatthewtennant/notekit-cli/issues --method POST`
- Mirrors the same pattern added to reminderkit-cli in https://github.com/johnmatthewtennant/reminderkit-cli/pull/15

## Verification
- [x] Build succeeds (`make`)
- [x] All tests pass (`./notekit test`)
- [x] Help output displays the new section correctly

## Test plan
- Run `notekit` with no arguments and verify the "Report issues" section appears at the bottom of the help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)