### PR TITLE
Add gh api issue reporting instructions to --help

### DIFF
--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2123,6 +2123,8 @@ static void usage(void) {
     fprintf(stderr, "\n");
     fprintf(stderr, "Testing:\n");
     fprintf(stderr, "  notekit test\n");
+    fprintf(stderr, "\nReport issues:\n");
+    fprintf(stderr, "  gh api repos/johnmatthewtennant/notekit-cli/issues --method POST -f title=\"...\" -f body=\"...\"\n");
 }
 
 


### PR DESCRIPTION
## Summary
- Adds "Report issues" section to `notekit --help` output with `gh api` command for filing GitHub issues
- Matches the existing pattern in reminderkit-cli

## Test plan
- [x] `make` builds successfully
- [x] `./notekit --help` shows the new "Report issues" section at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)