### PR TITLE
Defer CoreData init for commands that don't need Notes access

### DIFF
--- a/notekit.m
+++ b/notekit.m
@@ -67,6 +67,16 @@ int main(int argc, const char *argv[]) {
             return 1;
         }
 
+        // Reject unexpected positional arguments before loading frameworks
+        if (positional.count > 0 &&
+            ![command isEqualToString:@"folders"] &&
+            ![command isEqualToString:@"install-skill"] &&
+            ![command isEqualToString:@"test"]) {
+            fprintf(stderr, "Error: unexpected argument '%s'. All arguments must use --flag syntax.\n", [positional[0] UTF8String]);
+            usage();
+            return 1;
+        }
+
         // Handle commands that don't need Notes/CoreData access
         if ([command isEqualToString:@"install-skill"]) {
             BOOL wantClaude = [opts[@"claude"] isEqualToString:@"true"];
@@ -91,15 +101,6 @@ int main(int argc, const char *argv[]) {
 
         NSString *folderName = opts[@"folder"];
         id viewContext = getViewContext();
-
-        // Reject unexpected positional arguments
-        if (positional.count > 0 &&
-            ![command isEqualToString:@"folders"] &&
-            ![command isEqualToString:@"test"]) {
-            fprintf(stderr, "Error: unexpected argument '%s'. All arguments must use --flag syntax.\n", [positional[0] UTF8String]);
-            usage();
-            return 1;
-        }
 
         if ([command isEqualToString:@"folders"]) {
             return cmdFolders(viewContext);


### PR DESCRIPTION
## Summary

- Defer `loadFramework()` and `getViewContext()` until a command actually needs Notes/CoreData access
- Eliminates verbose CoreData/NoteStore.sqlite errors printed to stderr for non-Notes paths
- Adds proper `--help`/`-h` handling (as first argument and as flag on any subcommand)
- Validates command names before loading frameworks (unknown commands/typos exit cleanly)
- Moves positional argument validation before framework loading

### Paths that now skip CoreData entirely
- `notekit` (no args), `notekit --help`, `notekit -h`
- `notekit <command> --help`, `notekit <command> -h`
- `notekit <unknown-command>` (typos)
- `notekit <command> <unexpected-positional-arg>`
- `notekit install-skill [flags]`

### Scope note
Per-command required-flag validation (e.g. `notekit get` without `--title`) still happens after framework loading. Moving that earlier would require duplicating validation logic.

## Test plan
- [x] `notekit --help` prints usage, exit 0, no CoreData errors
- [x] `notekit list -h` prints usage, exit 0, no CoreData errors
- [x] `notekit install-skill --force` no CoreData errors on stderr
- [x] `notekit typo` Unknown command, no CoreData errors
- [x] `notekit list foo` unexpected argument, no CoreData errors
- [x] `notekit folders` still works correctly
- [x] `notekit test` all tests pass (exit 0)
- [x] Codex review: approved after 4 rounds

Fixes #31