### PR TITLE
Add permission error handling with troubleshooting instructions

### DIFF
--- a/generate-notes-cli.py
+++ b/generate-notes-cli.py
@@ -88,20 +88,40 @@ static void errorExit(NSString *msg) {
     exit(1);
 }
 
+// Recursively check an NSError chain for a specific domain+code pair.
+// Inspects the error itself, NSUnderlyingError, and NSDetailedErrors.
+static BOOL errorChainContains(NSError *error, NSString *domain, NSInteger code) {
+    if (!error) return NO;
+    if ([[error domain] isEqualToString:domain] && [error code] == code) return YES;
+    // Check single underlying error
+    NSError *underlying = [[error userInfo] objectForKey:@"NSUnderlyingError"];
+    if (errorChainContains(underlying, domain, code)) return YES;
+    // Check detailed errors array (Core Data batch errors)
+    NSArray *detailed = [[error userInfo] objectForKey:@"NSDetailedErrors"];
+    for (NSError *detail in detailed) {
+        if (errorChainContains(detail, domain, code)) return YES;
+    }
+    return NO;
+}
+
 // Check if a Core Data error is a permission/sandbox denial and print
 // actionable troubleshooting steps. Returns YES if it handled the error
 // (and exited), NO if the error is unrelated to permissions.
 static BOOL checkNotesAccessError(NSError *error) {
     if (!error) return NO;
     // NSCocoaErrorDomain 256 = NSFileReadNoPermissionError (sandbox / Full Disk Access)
-    // NSCocoaErrorDomain 4097 = NSXPCConnectionInterrupted (permission denied)
-    BOOL isSandbox = [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 256;
-    BOOL isPermDenied = [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097;
-    // Also check underlying errors — Core Data wraps SQLite errors
-    NSError *underlying = [[error userInfo] objectForKey:@"NSUnderlyingError"];
-    if (underlying) {
-        if ([[underlying domain] isEqualToString:@"NSSQLiteErrorDomain"] && [underlying code] == 23) {
-            isSandbox = YES; // SQLITE_AUTH
+    BOOL isSandbox = errorChainContains(error, @"NSCocoaErrorDomain", 256);
+    // NSSQLiteErrorDomain 23 = SQLITE_AUTH (sandbox denied at SQLite level)
+    if (!isSandbox) isSandbox = errorChainContains(error, @"NSSQLiteErrorDomain", 23);
+    // NSCocoaErrorDomain 4097 = NSXPCConnectionInterrupted — only treat as
+    // permission denied when the description mentions access/permission to
+    // avoid false positives from transient XPC failures.
+    BOOL isPermDenied = NO;
+    if (errorChainContains(error, @"NSCocoaErrorDomain", 4097)) {
+        NSString *desc = [[error localizedDescription] lowercaseString];
+        if ([desc containsString:@"permission"] || [desc containsString:@"denied"] ||
+            [desc containsString:@"access"]) {
+            isPermDenied = YES;
         }
     }
     if (!isSandbox && !isPermDenied) return NO;
@@ -222,7 +242,7 @@ static NSArray *findNotes(id viewContext, NSString *title, NSString *folderName)
     NSArray *notes = [viewContext executeFetchRequest:request error:&error];
     if (error) {
         checkNotesAccessError(error);
-        return @[];
+        errorExit([NSString stringWithFormat:@"Failed to find notes: %@", error]);
     }
     if (notes.count == 0) return @[];
     return notes;
@@ -262,7 +282,7 @@ static id findNoteByID(id viewContext, NSString *identifier) {
     NSArray *notes = [viewContext executeFetchRequest:request error:&error];
     if (error) {
         checkNotesAccessError(error);
-        return nil;
+        errorExit([NSString stringWithFormat:@"Failed to find note by ID: %@", error]);
     }
     if (notes.count == 0) return nil;
     return notes[0];

--- a/notekit-generated.m
+++ b/notekit-generated.m
@@ -32,20 +32,40 @@ static void errorExit(NSString *msg) {
     exit(1);
 }
 
+// Recursively check an NSError chain for a specific domain+code pair.
+// Inspects the error itself, NSUnderlyingError, and NSDetailedErrors.
+static BOOL errorChainContains(NSError *error, NSString *domain, NSInteger code) {
+    if (!error) return NO;
+    if ([[error domain] isEqualToString:domain] && [error code] == code) return YES;
+    // Check single underlying error
+    NSError *underlying = [[error userInfo] objectForKey:@"NSUnderlyingError"];
+    if (errorChainContains(underlying, domain, code)) return YES;
+    // Check detailed errors array (Core Data batch errors)
+    NSArray *detailed = [[error userInfo] objectForKey:@"NSDetailedErrors"];
+    for (NSError *detail in detailed) {
+        if (errorChainContains(detail, domain, code)) return YES;
+    }
+    return NO;
+}
+
 // Check if a Core Data error is a permission/sandbox denial and print
 // actionable troubleshooting steps. Returns YES if it handled the error
 // (and exited), NO if the error is unrelated to permissions.
 static BOOL checkNotesAccessError(NSError *error) {
     if (!error) return NO;
     // NSCocoaErrorDomain 256 = NSFileReadNoPermissionError (sandbox / Full Disk Access)
-    // NSCocoaErrorDomain 4097 = NSXPCConnectionInterrupted (permission denied)
-    BOOL isSandbox = [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 256;
-    BOOL isPermDenied = [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097;
-    // Also check underlying errors — Core Data wraps SQLite errors
-    NSError *underlying = [[error userInfo] objectForKey:@"NSUnderlyingError"];
-    if (underlying) {
-        if ([[underlying domain] isEqualToString:@"NSSQLiteErrorDomain"] && [underlying code] == 23) {
-            isSandbox = YES; // SQLITE_AUTH
+    BOOL isSandbox = errorChainContains(error, @"NSCocoaErrorDomain", 256);
+    // NSSQLiteErrorDomain 23 = SQLITE_AUTH (sandbox denied at SQLite level)
+    if (!isSandbox) isSandbox = errorChainContains(error, @"NSSQLiteErrorDomain", 23);
+    // NSCocoaErrorDomain 4097 = NSXPCConnectionInterrupted — only treat as
+    // permission denied when the description mentions access/permission to
+    // avoid false positives from transient XPC failures.
+    BOOL isPermDenied = NO;
+    if (errorChainContains(error, @"NSCocoaErrorDomain", 4097)) {
+        NSString *desc = [[error localizedDescription] lowercaseString];
+        if ([desc containsString:@"permission"] || [desc containsString:@"denied"] ||
+            [desc containsString:@"access"]) {
+            isPermDenied = YES;
         }
     }
     if (!isSandbox && !isPermDenied) return NO;
@@ -164,7 +184,7 @@ static NSArray *findNotes(id viewContext, NSString *title, NSString *folderName)
     NSArray *notes = [viewContext executeFetchRequest:request error:&error];
     if (error) {
         checkNotesAccessError(error);
-        return @[];
+        errorExit([NSString stringWithFormat:@"Failed to find notes: %@", error]);
     }
     if (notes.count == 0) return @[];
     return notes;
@@ -204,7 +224,7 @@ static id findNoteByID(id viewContext, NSString *identifier) {
     NSArray *notes = [viewContext executeFetchRequest:request error:&error];
     if (error) {
         checkNotesAccessError(error);
-        return nil;
+        errorExit([NSString stringWithFormat:@"Failed to find note by ID: %@", error]);
     }
     if (notes.count == 0) return nil;
     return notes[0];

--- a/notekit-tests.m
+++ b/notekit-tests.m
@@ -4058,6 +4058,75 @@ static int cmdTest(id viewContext) {
         } else { fprintf(stderr, "  FAIL (folder not found to delete)\n"); failed++; }
     }
 
+    // --- Permission error detection tests ---
+
+    // Test: errorChainContains detects top-level error
+    {
+        fprintf(stderr, "errorChainContains: top-level match...");
+        NSError *err = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:256 userInfo:nil];
+        if (errorChainContains(err, @"NSCocoaErrorDomain", 256)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: errorChainContains detects nested underlying error
+    {
+        fprintf(stderr, "errorChainContains: nested underlying error...");
+        NSError *inner = [NSError errorWithDomain:@"NSSQLiteErrorDomain" code:23 userInfo:nil];
+        NSError *outer = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:256
+            userInfo:@{@"NSUnderlyingError": inner}];
+        if (errorChainContains(outer, @"NSSQLiteErrorDomain", 23)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: errorChainContains detects error in NSDetailedErrors array
+    {
+        fprintf(stderr, "errorChainContains: detailed errors array...");
+        NSError *detail = [NSError errorWithDomain:@"NSSQLiteErrorDomain" code:23 userInfo:nil];
+        NSError *outer = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:1560
+            userInfo:@{@"NSDetailedErrors": @[detail]}];
+        if (errorChainContains(outer, @"NSSQLiteErrorDomain", 23)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: errorChainContains returns NO for non-matching error
+    {
+        fprintf(stderr, "errorChainContains: no match...");
+        NSError *err = [NSError errorWithDomain:@"SomeOtherDomain" code:42 userInfo:nil];
+        if (!errorChainContains(err, @"NSCocoaErrorDomain", 256)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: checkNotesAccessError returns NO for unrelated errors
+    {
+        fprintf(stderr, "checkNotesAccessError: unrelated error returns NO...");
+        NSError *err = [NSError errorWithDomain:@"SomeOtherDomain" code:42 userInfo:nil];
+        if (!checkNotesAccessError(err)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: checkNotesAccessError returns NO for nil
+    {
+        fprintf(stderr, "checkNotesAccessError: nil returns NO...");
+        if (!checkNotesAccessError(nil)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
+    // Test: checkNotesAccessError returns NO for 4097 without permission keywords
+    {
+        fprintf(stderr, "checkNotesAccessError: 4097 without permission keywords returns NO...");
+        NSError *err = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:4097
+            userInfo:@{NSLocalizedDescriptionKey: @"XPC connection interrupted"}];
+        if (!checkNotesAccessError(err)) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else { fprintf(stderr, "  FAIL\n"); failed++; }
+    }
+
     fprintf(stderr, "\nResults: %d passed, %d failed\n", passed, failed);
     return failed > 0 ? 1 : 0;
 }


### PR DESCRIPTION
## Summary
- Add `checkNotesAccessError()` helper that detects permission/sandbox errors and prints actionable Full Disk Access troubleshooting steps
- Add `errorChainContains()` to recursively inspect nested Core Data errors (NSUnderlyingError + NSDetailedErrors)
- Handle 3 error conditions: NSCocoaErrorDomain 256, NSSQLiteErrorDomain 23, NSCocoaErrorDomain 4097 (with keyword guard)
- Fix silent error swallowing in `findNotes()` and `findNoteByID()` — non-permission errors now call `errorExit`
- Add 7 unit tests for permission error detection

Fixes #34

## Test plan
- [x] All 127 tests pass (120 existing + 7 new)
- [x] Smoke test: `notekit folders` works correctly
- [x] Binary installed to `/opt/homebrew/bin/notekit`
- [x] Codex review approved (2 rounds)
- [ ] Manual: Revoke Full Disk Access and verify error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)