### PR TITLE
Add coding agent instructions to FDA error message

### DIFF
--- a/generate-notes-cli.py
+++ b/generate-notes-cli.py
@@ -109,28 +109,32 @@ static void errorExit(NSString *msg) {
     exit(1);
 }
 
-// Print Full Disk Access troubleshooting steps to stderr (no preamble).
-// Callers provide their own context before calling this.
+// Return Full Disk Access troubleshooting text (no preamble).
+// Testable: callers can inspect the string; printFDATroubleshootingSteps() prints it.
+static NSString *fdaTroubleshootingText(void) {
+    return @"  1. Open Full Disk Access settings (run this command):\\n"
+           @"     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n"
+           @"  2. Add your terminal app (e.g. iTerm, Terminal, Ghostty) and toggle it ON\\n\\n"
+           @"If you previously denied access, reset first:\\n"
+           @"   tccutil reset SystemPolicyAllFiles <bundle-id>\\n\\n"
+           @"   Find your terminal\'s bundle ID:\\n"
+           @"   osascript -e \'id of app \\"iTerm\\"\'  (replace iTerm with your terminal app name)\\n\\n"
+           @"   Then re-open settings and toggle your terminal ON:\\n"
+           @"     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n"
+           @"Then retry: notekit folders\\n\\n"
+           @"If you are a coding agent helping the user:\\n"
+           @"  1. Find the host app bundle ID (terminal or IDE that runs notekit):\\n"
+           @"     osascript -e \'id of app \\"Terminal\\"\'\\n"
+           @"     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\\n"
+           @"  2. Reset prior denial (if user previously clicked Don\'t Allow):\\n"
+           @"     tccutil reset SystemPolicyAllFiles <bundle-id>\\n"
+           @"  3. Open the Full Disk Access pane:\\n"
+           @"     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n"
+           @"  4. Ask the user to toggle their app ON in the list, then retry.\\n";
+}
+
 static void printFDATroubleshootingSteps(void) {
-    fprintf(stderr, "  1. Open Full Disk Access settings (run this command):\\n");
-    fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n");
-    fprintf(stderr, "  2. Add your terminal app (e.g. iTerm, Terminal, Ghostty) and toggle it ON\\n\\n");
-    fprintf(stderr, "If you previously denied access, reset first:\\n");
-    fprintf(stderr, "   tccutil reset SystemPolicyAllFiles <bundle-id>\\n\\n");
-    fprintf(stderr, "   Find your terminal\'s bundle ID:\\n");
-    fprintf(stderr, "   osascript -e \'id of app \\"iTerm\\"\'  (replace iTerm with your terminal app name)\\n\\n");
-    fprintf(stderr, "   Then re-open settings and toggle your terminal ON:\\n");
-    fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n");
-    fprintf(stderr, "Then retry: notekit folders\\n\\n");
-    fprintf(stderr, "If you are a coding agent helping the user:\\n");
-    fprintf(stderr, "  1. Find the host app bundle ID (terminal or IDE that runs notekit):\\n");
-    fprintf(stderr, "     osascript -e 'id of app \\"Terminal\\"'\\n");
-    fprintf(stderr, "     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\\n");
-    fprintf(stderr, "  2. Reset prior denial (if user previously clicked Don't Allow):\\n");
-    fprintf(stderr, "     tccutil reset SystemPolicyAllFiles <bundle-id>\\n");
-    fprintf(stderr, "  3. Open the Full Disk Access pane:\\n");
-    fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n");
-    fprintf(stderr, "  4. Ask the user to toggle their app ON in the list, then retry.\\n");
+    fprintf(stderr, "%s", [fdaTroubleshootingText() UTF8String]);
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/generate-notes-cli.py
+++ b/generate-notes-cli.py
@@ -121,7 +121,14 @@ static void printFDATroubleshootingSteps(void) {
     fprintf(stderr, "   osascript -e \'id of app \\"iTerm\\"\'  (replace iTerm with your terminal app name)\\n\\n");
     fprintf(stderr, "   Then re-open settings and toggle your terminal ON:\\n");
     fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n");
-    fprintf(stderr, "Then retry: notekit folders\\n");
+    fprintf(stderr, "Then retry: notekit folders\\n\\n");
+    fprintf(stderr, "If you are a coding agent helping the user:\\n");
+    fprintf(stderr, "  1. Find the terminal bundle ID:\\n");
+    fprintf(stderr, "     osascript -e 'id of app \\"Terminal\\"'\\n");
+    fprintf(stderr, "     (replace Terminal with the user's terminal app)\\n");
+    fprintf(stderr, "  2. Open the Full Disk Access pane directly:\\n");
+    fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n");
+    fprintf(stderr, "  3. Ask the user to add their terminal app, then retry.\\n");
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/generate-notes-cli.py
+++ b/generate-notes-cli.py
@@ -123,12 +123,14 @@ static void printFDATroubleshootingSteps(void) {
     fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n\\n");
     fprintf(stderr, "Then retry: notekit folders\\n\\n");
     fprintf(stderr, "If you are a coding agent helping the user:\\n");
-    fprintf(stderr, "  1. Find the terminal bundle ID:\\n");
+    fprintf(stderr, "  1. Find the host app bundle ID (terminal or IDE that runs notekit):\\n");
     fprintf(stderr, "     osascript -e 'id of app \\"Terminal\\"'\\n");
-    fprintf(stderr, "     (replace Terminal with the user's terminal app)\\n");
-    fprintf(stderr, "  2. Open the Full Disk Access pane directly:\\n");
+    fprintf(stderr, "     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\\n");
+    fprintf(stderr, "  2. Reset prior denial (if user previously clicked Don't Allow):\\n");
+    fprintf(stderr, "     tccutil reset SystemPolicyAllFiles <bundle-id>\\n");
+    fprintf(stderr, "  3. Open the Full Disk Access pane:\\n");
     fprintf(stderr, "     open \\"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\\"\\n");
-    fprintf(stderr, "  3. Ask the user to add their terminal app, then retry.\\n");
+    fprintf(stderr, "  4. Ask the user to toggle their app ON in the list, then retry.\\n");
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/notekit-generated.m
+++ b/notekit-generated.m
@@ -65,7 +65,14 @@ static void printFDATroubleshootingSteps(void) {
     fprintf(stderr, "   osascript -e 'id of app \"iTerm\"'  (replace iTerm with your terminal app name)\n\n");
     fprintf(stderr, "   Then re-open settings and toggle your terminal ON:\n");
     fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n");
-    fprintf(stderr, "Then retry: notekit folders\n");
+    fprintf(stderr, "Then retry: notekit folders\n\n");
+    fprintf(stderr, "If you are a coding agent helping the user:\n");
+    fprintf(stderr, "  1. Find the terminal bundle ID:\n");
+    fprintf(stderr, "     osascript -e 'id of app \"Terminal\"'\n");
+    fprintf(stderr, "     (replace Terminal with the user's terminal app)\n");
+    fprintf(stderr, "  2. Open the Full Disk Access pane directly:\n");
+    fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n");
+    fprintf(stderr, "  3. Ask the user to add their terminal app, then retry.\n");
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/notekit-generated.m
+++ b/notekit-generated.m
@@ -53,28 +53,32 @@ static void errorExit(NSString *msg) {
     exit(1);
 }
 
-// Print Full Disk Access troubleshooting steps to stderr (no preamble).
-// Callers provide their own context before calling this.
+// Return Full Disk Access troubleshooting text (no preamble).
+// Testable: callers can inspect the string; printFDATroubleshootingSteps() prints it.
+static NSString *fdaTroubleshootingText(void) {
+    return @"  1. Open Full Disk Access settings (run this command):\n"
+           @"     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n"
+           @"  2. Add your terminal app (e.g. iTerm, Terminal, Ghostty) and toggle it ON\n\n"
+           @"If you previously denied access, reset first:\n"
+           @"   tccutil reset SystemPolicyAllFiles <bundle-id>\n\n"
+           @"   Find your terminal's bundle ID:\n"
+           @"   osascript -e 'id of app \"iTerm\"'  (replace iTerm with your terminal app name)\n\n"
+           @"   Then re-open settings and toggle your terminal ON:\n"
+           @"     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n"
+           @"Then retry: notekit folders\n\n"
+           @"If you are a coding agent helping the user:\n"
+           @"  1. Find the host app bundle ID (terminal or IDE that runs notekit):\n"
+           @"     osascript -e 'id of app \"Terminal\"'\n"
+           @"     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\n"
+           @"  2. Reset prior denial (if user previously clicked Don't Allow):\n"
+           @"     tccutil reset SystemPolicyAllFiles <bundle-id>\n"
+           @"  3. Open the Full Disk Access pane:\n"
+           @"     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n"
+           @"  4. Ask the user to toggle their app ON in the list, then retry.\n";
+}
+
 static void printFDATroubleshootingSteps(void) {
-    fprintf(stderr, "  1. Open Full Disk Access settings (run this command):\n");
-    fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n");
-    fprintf(stderr, "  2. Add your terminal app (e.g. iTerm, Terminal, Ghostty) and toggle it ON\n\n");
-    fprintf(stderr, "If you previously denied access, reset first:\n");
-    fprintf(stderr, "   tccutil reset SystemPolicyAllFiles <bundle-id>\n\n");
-    fprintf(stderr, "   Find your terminal's bundle ID:\n");
-    fprintf(stderr, "   osascript -e 'id of app \"iTerm\"'  (replace iTerm with your terminal app name)\n\n");
-    fprintf(stderr, "   Then re-open settings and toggle your terminal ON:\n");
-    fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n");
-    fprintf(stderr, "Then retry: notekit folders\n\n");
-    fprintf(stderr, "If you are a coding agent helping the user:\n");
-    fprintf(stderr, "  1. Find the host app bundle ID (terminal or IDE that runs notekit):\n");
-    fprintf(stderr, "     osascript -e 'id of app \"Terminal\"'\n");
-    fprintf(stderr, "     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\n");
-    fprintf(stderr, "  2. Reset prior denial (if user previously clicked Don't Allow):\n");
-    fprintf(stderr, "     tccutil reset SystemPolicyAllFiles <bundle-id>\n");
-    fprintf(stderr, "  3. Open the Full Disk Access pane:\n");
-    fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n");
-    fprintf(stderr, "  4. Ask the user to toggle their app ON in the list, then retry.\n");
+    fprintf(stderr, "%s", [fdaTroubleshootingText() UTF8String]);
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/notekit-generated.m
+++ b/notekit-generated.m
@@ -67,12 +67,14 @@ static void printFDATroubleshootingSteps(void) {
     fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n\n");
     fprintf(stderr, "Then retry: notekit folders\n\n");
     fprintf(stderr, "If you are a coding agent helping the user:\n");
-    fprintf(stderr, "  1. Find the terminal bundle ID:\n");
+    fprintf(stderr, "  1. Find the host app bundle ID (terminal or IDE that runs notekit):\n");
     fprintf(stderr, "     osascript -e 'id of app \"Terminal\"'\n");
-    fprintf(stderr, "     (replace Terminal with the user's terminal app)\n");
-    fprintf(stderr, "  2. Open the Full Disk Access pane directly:\n");
+    fprintf(stderr, "     (replace Terminal with the actual app: iTerm, Ghostty, Cursor, VS Code, etc.)\n");
+    fprintf(stderr, "  2. Reset prior denial (if user previously clicked Don't Allow):\n");
+    fprintf(stderr, "     tccutil reset SystemPolicyAllFiles <bundle-id>\n");
+    fprintf(stderr, "  3. Open the Full Disk Access pane:\n");
     fprintf(stderr, "     open \"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\"\n");
-    fprintf(stderr, "  3. Ask the user to add their terminal app, then retry.\n");
+    fprintf(stderr, "  4. Ask the user to toggle their app ON in the list, then retry.\n");
 }
 
 // Recursively check an NSError chain for a specific domain+code pair.

--- a/notekit-tests.m
+++ b/notekit-tests.m
@@ -4100,6 +4100,24 @@ static int cmdTest(id viewContext) {
         } else { fprintf(stderr, "  FAIL\n"); failed++; }
     }
 
+    // Test: fdaTroubleshootingText contains agent instructions
+    {
+        fprintf(stderr, "fdaTroubleshootingText: contains agent instructions...");
+        NSString *text = fdaTroubleshootingText();
+        BOOL hasAgentHeader = [text containsString:@"coding agent helping the user"];
+        BOOL hasBundleId = [text containsString:@"osascript -e 'id of app"];
+        BOOL hasTccutil = [text containsString:@"tccutil reset SystemPolicyAllFiles"];
+        BOOL hasOpenSettings = [text containsString:@"x-apple.systempreferences"];
+        BOOL hasIDEMention = [text containsString:@"Cursor, VS Code"];
+        if (hasAgentHeader && hasBundleId && hasTccutil && hasOpenSettings && hasIDEMention) {
+            fprintf(stderr, "  PASS\n"); passed++;
+        } else {
+            fprintf(stderr, "  FAIL (header=%d, bundle=%d, tccutil=%d, settings=%d, ide=%d)\n",
+                hasAgentHeader, hasBundleId, hasTccutil, hasOpenSettings, hasIDEMention);
+            failed++;
+        }
+    }
+
     // Test: checkNotesAccessError returns NO for unrelated errors
     {
         fprintf(stderr, "checkNotesAccessError: unrelated error returns NO...");


### PR DESCRIPTION
## Summary
- Adds a "If you are a coding agent helping the user" section to the Full Disk Access error output
- Gives agents explicit commands: find terminal/IDE bundle ID, reset prior denial via tccutil, open FDA settings pane, and ask user to toggle access
- Refactored `printFDATroubleshootingSteps()` to use `fdaTroubleshootingText()` returning NSString* for testability
- Updated both `generate-notes-cli.py` (source of truth) and regenerated `notekit-generated.m`

Closes #38

## Test plan
- [x] `make` builds successfully
- [x] All 128 tests pass (`./notekit test`) — 127 existing + 1 new
- [x] New test: `fdaTroubleshootingText: contains agent instructions` verifies all key elements
- [ ] Manual: trigger FDA error to verify output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)