### PR TITLE
Document note-to-note link markdown syntax

### DIFF
--- a/.agents/skills/apple-notes/SKILL.md
+++ b/.agents/skills/apple-notes/SKILL.md
@@ -12,6 +12,12 @@ Command-line interface for Apple Notes. Built on the private NotesShared framewo
 
 Use `read-markdown` / `write-markdown` for all note operations. With `--diff`, `write-markdown` does paragraph-level LCS diffing — only mutated paragraphs are changed. Markdown covers headings, bold, italic, strikethrough, links, code, lists, checklists, and note-to-note links. Primitive commands (see "Debugging / Internals" in `--help`) exist for edge cases not covered by markdown syntax.
 
+### Note-to-note links in markdown
+
+`read-markdown` outputs note links as `[Display Text](applenotes://showNote?identifier=NOTE_ID)`. `write-markdown` accepts the same syntax and converts them to native note links. Get a note's ID with `notekit get --title "Target" | jq -r .id`. No need to use primitive `add-note-link` — just write the markdown link.
+
+### Commands
+
 - `notekit read-markdown --title "Title"` — read a note as markdown
 - `notekit read-markdown --id <id>` — read a note as markdown by ID
 - `notekit write-markdown --id <id> < file.md` — update note from markdown (pipe or stdin)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Convenience (composed from primitives):
   notekit --help                               # full usage
 ```
 
+## Note-to-note links
+
+`read-markdown` outputs note-to-note links as standard markdown links with `applenotes://` URLs:
+
+```
+[Display Text](applenotes://showNote?identifier=NOTE_ID)
+```
+
+`write-markdown` recognizes this syntax and converts them back to native Apple Notes inline link attachments. To get a note's ID for linking:
+
+```bash
+notekit get --title "Target Note" | jq -r .id
+```
+
 ## Private API Notice
 
 Uses Apple's private `NotesShared.framework`. Not endorsed by Apple. May break with macOS updates.

--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2097,6 +2097,11 @@ static void usage(void) {
     fprintf(stderr, "code, lists, checklists, and note-to-note links. Primitives exist for edge\n");
     fprintf(stderr, "cases not covered by markdown syntax.\n");
     fprintf(stderr, "\n");
+    fprintf(stderr, "Note-to-note links:\n");
+    fprintf(stderr, "  read-markdown outputs note links as:  [Display Text](applenotes://showNote?identifier=NOTE_ID)\n");
+    fprintf(stderr, "  write-markdown accepts the same syntax and converts them back to native note links.\n");
+    fprintf(stderr, "  To get a note's ID for linking, use:  notekit get --title \"Target Note\" | jq -r .id\n");
+    fprintf(stderr, "\n");
     fprintf(stderr, "Reading and writing notes (recommended):\n");
     fprintf(stderr, "  notekit read-markdown (--title <title> | --id <id>) [--folder <name>]\n");
     fprintf(stderr, "  notekit write-markdown --id <id> [--dry-run] [--backup] [--diff]    Read markdown from stdin, replace note content\n");


### PR DESCRIPTION
## Summary

- Documents the `[Display Text](applenotes://showNote?identifier=NOTE_ID)` syntax that `read-markdown`/`write-markdown` use for note-to-note links
- Adds a "Note-to-note links" section to `--help` output, `README.md`, and `SKILL.md`
- Agents were falling back to the `add-note-link` primitive because the markdown syntax wasn't documented anywhere

## Test plan

- [x] `make` builds successfully
- [x] `notekit --help` shows the new "Note-to-note links" section
- [ ] Verify SKILL.md renders correctly when loaded by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)