### PR TITLE
Make install-skill idempotent without --force

### DIFF
--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2059,9 +2059,9 @@ static int cmdInstallSkill(BOOL installClaude, BOOL installAgents, BOOL force) {
     int failures = 0;
     for (NSString *dir in targetDirs) {
         NSString *path = [dir stringByAppendingPathComponent:@"SKILL.md"];
-        if ([fm fileExistsAtPath:path]) {
-            // Check if it's already a symlink pointing to the same source
-            NSDictionary *attrs = [fm attributesOfItemAtPath:path error:nil];
+        // Use attributesOfItemAtPath (not fileExistsAtPath) to detect broken symlinks
+        NSDictionary *attrs = [fm attributesOfItemAtPath:path error:nil];
+        if (attrs) {
             if (!force && [attrs[NSFileType] isEqualToString:NSFileTypeSymbolicLink]) {
                 NSString *dest = [fm destinationOfSymbolicLinkAtPath:path error:nil];
                 if ([dest isEqualToString:sourcePath]) {
@@ -2069,6 +2069,7 @@ static int cmdInstallSkill(BOOL installClaude, BOOL installAgents, BOOL force) {
                     continue;
                 }
             }
+            printf("Replacing existing %s\n", [path UTF8String]);
             [fm removeItemAtPath:path error:nil];
         }
         if (![fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:&error]) {

--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2060,10 +2060,14 @@ static int cmdInstallSkill(BOOL installClaude, BOOL installAgents, BOOL force) {
     for (NSString *dir in targetDirs) {
         NSString *path = [dir stringByAppendingPathComponent:@"SKILL.md"];
         if ([fm fileExistsAtPath:path]) {
-            if (!force) {
-                fprintf(stderr, "Error: %s already exists (use --force to overwrite)\n", [path UTF8String]);
-                failures++;
-                continue;
+            // Check if it's already a symlink pointing to the same source
+            NSDictionary *attrs = [fm attributesOfItemAtPath:path error:nil];
+            if (!force && [attrs[NSFileType] isEqualToString:NSFileTypeSymbolicLink]) {
+                NSString *dest = [fm destinationOfSymbolicLinkAtPath:path error:nil];
+                if ([dest isEqualToString:sourcePath]) {
+                    printf("Skill already installed: %s -> %s\n", [path UTF8String], [sourcePath UTF8String]);
+                    continue;
+                }
             }
             [fm removeItemAtPath:path error:nil];
         }


### PR DESCRIPTION
## Summary
- `install-skill` now replaces existing real files (e.g. from `sq agents skills`) and stale symlinks without requiring `--force`
- When the symlink already points to the correct source, prints "already installed" and skips
- `--force` still works to re-create even a correct symlink

## Test plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Tested: real file at target → replaced with symlink (no `--force`)
- [x] Tested: correct symlink at target → "already installed" message, no-op
- [x] Tested: `--force` with correct symlink → re-creates symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)