### PR TITLE
Fix CRDT shared-note paragraph fragmentation (#48)

### DIFF
--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -447,14 +447,22 @@ static NSArray *noteToParaModel(id note) {
         }
     }
 
+    // Paragraph boundaries are newline characters (U+000A) in the text — not
+    // TTStyle UUID changes. Canonical notes often have one TTStyle UUID
+    // covering many paragraphs separated by \n; shared/CRDT notes can have
+    // many distinct UUIDs within a single paragraph. Splitting on UUID
+    // therefore over-fragments shared notes (issue #48) and previously
+    // collapsed real paragraph breaks in canonical notes into soft line
+    // breaks. Splitting on \n is the semantic truth in either case.
     NSMutableArray *paragraphs = [NSMutableArray array];
     NSMutableString *currentText = [NSMutableString string];
     NSMutableArray *currentRuns = [NSMutableArray array];
     NSString *currentUUID = nil;
-    NSInteger currentStyle = -1;
+    NSInteger currentStyle = 3;
     BOOL currentTodoDone = NO;
     NSUInteger currentIndent = 0;
     NSUInteger runOffsetInPara = 0;
+    BOOL paragraphAttrsCaptured = NO;
     NSUInteger idx = 0;
     NSRange effectiveRange;
 
@@ -469,81 +477,76 @@ static NSArray *noteToParaModel(id note) {
         NSUInteger indent = style ? ((NSUInteger (*)(id, SEL))objc_msgSend)(style, sel_registerName("indent")) : 0;
         NSString *chunk = [fullText substringWithRange:effectiveRange];
 
-        if (currentUUID && [uuid isEqualToString:currentUUID]) {
-            // Same paragraph, accumulate text and runs
-            NSMutableDictionary *run = [NSMutableDictionary dictionary];
-            run[@"start"] = @(runOffsetInPara);
-            run[@"length"] = @(chunk.length);
-            id nsLink = attrs[@"NSLink"];
-            if (nsLink) run[@"link"] = [nsLink description];
-            // Check for note-to-note link attachment (￼ chars with NSAttachment)
-            id nsAttachment = attrs[@"NSAttachment"];
-            if (nsAttachment && !nsLink && [chunk isEqualToString:@"\uFFFC"]) {
-                NSDictionary *noteLink = noteLinksByOffset[@(effectiveRange.location)];
-                if (noteLink) {
-                    run[@"link"] = noteLink[@"url"];
-                    run[@"noteLinkDisplayText"] = noteLink[@"displayText"];
-                }
-            }
-            id strikethrough = attrs[@"TTStrikethrough"];
-            if (strikethrough) run[@"strikethrough"] = @YES;
-            id ttHints1 = attrs[@"TTHints"];
-            if (ttHints1) {
-                NSUInteger hints1 = [ttHints1 unsignedIntegerValue];
-                if (hints1 & 1) run[@"bold"] = @YES;
-                if (hints1 & 2) run[@"italic"] = @YES;
-            }
-            id ttUnderline1 = attrs[@"TTUnderline"];
-            if (ttUnderline1) run[@"underline"] = @YES;
-            [currentRuns addObject:run];
-            [currentText appendString:chunk];
-            runOffsetInPara += chunk.length;
-        } else {
-            // New paragraph - emit previous
-            if (currentText.length > 0) {
-                emitParagraph(paragraphs, currentText, currentRuns,
-                    currentStyle, currentIndent, currentTodoDone, currentUUID);
-            }
-            currentText = [NSMutableString stringWithString:chunk];
-            currentRuns = [NSMutableArray array];
-            currentUUID = uuid;
-            currentStyle = styleNum;
-            currentTodoDone = done;
-            currentIndent = indent;
-            runOffsetInPara = 0;
+        // Walk chunk segment-by-segment: each segment is text bounded by \n
+        // (or chunk start/end). Segments continue the current paragraph;
+        // each \n terminates it.
+        NSUInteger chunkPos = 0;
+        while (chunkPos < chunk.length) {
+            NSRange searchRange = NSMakeRange(chunkPos, chunk.length - chunkPos);
+            NSRange newlineRange = [chunk rangeOfString:@"\n" options:0 range:searchRange];
+            NSUInteger sliceEnd = (newlineRange.location != NSNotFound) ? newlineRange.location : chunk.length;
+            NSUInteger sliceLen = sliceEnd - chunkPos;
 
-            NSMutableDictionary *run = [NSMutableDictionary dictionary];
-            run[@"start"] = @(0);
-            run[@"length"] = @(chunk.length);
-            id nsLink = attrs[@"NSLink"];
-            if (nsLink) run[@"link"] = [nsLink description];
-            // Check for note-to-note link attachment (￼ chars with NSAttachment)
-            id nsAttachment = attrs[@"NSAttachment"];
-            if (nsAttachment && !nsLink && [chunk isEqualToString:@"\uFFFC"]) {
-                NSDictionary *noteLink = noteLinksByOffset[@(effectiveRange.location)];
-                if (noteLink) {
-                    run[@"link"] = noteLink[@"url"];
-                    run[@"noteLinkDisplayText"] = noteLink[@"displayText"];
+            // Capture paragraph-level attrs from the first chunk that
+            // contributes to this paragraph. Subsequent chunks (which may
+            // have different UUIDs in CRDT notes) keep the same paragraph
+            // and only add inline attribute info via per-run entries.
+            if (!paragraphAttrsCaptured) {
+                currentStyle = styleNum;
+                currentTodoDone = done;
+                currentIndent = indent;
+                currentUUID = uuid;
+                paragraphAttrsCaptured = YES;
+            }
+
+            if (sliceLen > 0) {
+                NSString *sliceText = [chunk substringWithRange:NSMakeRange(chunkPos, sliceLen)];
+                NSUInteger sliceGlobalOffset = effectiveRange.location + chunkPos;
+
+                NSMutableDictionary *run = [NSMutableDictionary dictionary];
+                run[@"start"] = @(runOffsetInPara);
+                run[@"length"] = @(sliceLen);
+                id nsLink = attrs[@"NSLink"];
+                if (nsLink) run[@"link"] = [nsLink description];
+                id nsAttachment = attrs[@"NSAttachment"];
+                if (nsAttachment && !nsLink && [sliceText isEqualToString:@"￼"]) {
+                    NSDictionary *noteLink = noteLinksByOffset[@(sliceGlobalOffset)];
+                    if (noteLink) {
+                        run[@"link"] = noteLink[@"url"];
+                        run[@"noteLinkDisplayText"] = noteLink[@"displayText"];
+                    }
                 }
+                id strikethrough = attrs[@"TTStrikethrough"];
+                if (strikethrough) run[@"strikethrough"] = @YES;
+                id ttHints = attrs[@"TTHints"];
+                if (ttHints) {
+                    NSUInteger hints = [ttHints unsignedIntegerValue];
+                    if (hints & 1) run[@"bold"] = @YES;
+                    if (hints & 2) run[@"italic"] = @YES;
+                }
+                id ttUnderline = attrs[@"TTUnderline"];
+                if (ttUnderline) run[@"underline"] = @YES;
+                [currentRuns addObject:run];
+                [currentText appendString:sliceText];
+                runOffsetInPara += sliceLen;
             }
-            id strikethrough = attrs[@"TTStrikethrough"];
-            if (strikethrough) run[@"strikethrough"] = @YES;
-            id ttHints2 = attrs[@"TTHints"];
-            if (ttHints2) {
-                NSUInteger hints2 = [ttHints2 unsignedIntegerValue];
-                if (hints2 & 1) run[@"bold"] = @YES;
-                if (hints2 & 2) run[@"italic"] = @YES;
-            }
-            id ttUnderline2 = attrs[@"TTUnderline"];
-            if (ttUnderline2) run[@"underline"] = @YES;
-            [currentRuns addObject:run];
-            runOffsetInPara = chunk.length;
+
+            if (newlineRange.location == NSNotFound) break;
+
+            // Hit a paragraph boundary: emit current paragraph and reset.
+            emitParagraph(paragraphs, currentText, currentRuns,
+                currentStyle, currentIndent, currentTodoDone, currentUUID);
+            currentText = [NSMutableString string];
+            currentRuns = [NSMutableArray array];
+            runOffsetInPara = 0;
+            paragraphAttrsCaptured = NO;
+            chunkPos = newlineRange.location + 1;
         }
 
         idx = effectiveRange.location + effectiveRange.length;
     }
-    // Emit last paragraph
-    if (currentText.length > 0) {
+    // Emit final paragraph if anything was captured.
+    if (paragraphAttrsCaptured) {
         emitParagraph(paragraphs, currentText, currentRuns,
             currentStyle, currentIndent, currentTodoDone, currentUUID);
     }
@@ -2234,11 +2237,28 @@ static int cmdExport(id viewContext, NSString *outputPath, NSString *folderFilte
             NSString *body = noteToMarkdownString(note);
             if (body) {
                 if (!preserveRoundTrip) {
+                    // Double single \n paragraph separators into blank lines
+                    // so paragraphs render correctly in any markdown viewer
+                    // (the model emits paragraphs joined by single \n; that
+                    // works in Obsidian's non-strict mode but not CommonMark/
+                    // GitHub).  Skip \n's that are already part of a blank-
+                    // line sequence so we don't multiply them.
+                    NSMutableString *withBlanks = [NSMutableString stringWithCapacity:body.length];
+                    for (NSUInteger i = 0; i < body.length; i++) {
+                        unichar c = [body characterAtIndex:i];
+                        [withBlanks appendFormat:@"%C", c];
+                        if (c == '\n') {
+                            BOOL prevNL = (i > 0 && [body characterAtIndex:i - 1] == '\n');
+                            BOOL nextNL = (i + 1 < body.length && [body characterAtIndex:i + 1] == '\n');
+                            if (!prevNL && !nextNL) [withBlanks appendString:@"\n"];
+                        }
+                    }
+                    body = withBlanks;
                     // Soft line breaks (U+2028, emitted as <br>) become
-                    // markdown hard breaks. unescapeMarkdown removes the
-                    // defensive backslash-escaping that exists for write-
-                    // markdown round-trip. Output is no longer round-trippable
-                    // but reads cleanly as plain text.
+                    // markdown hard breaks.  unescapeMarkdown removes the
+                    // defensive backslash escaping that exists for write-
+                    // markdown round-trip.  Output is no longer round-
+                    // trippable but reads cleanly as plain text.
                     body = [body stringByReplacingOccurrencesOfString:@"<br>" withString:@"  \n"];
                     body = unescapeMarkdown(body);
                 }

--- a/notekit-tests.m
+++ b/notekit-tests.m
@@ -2660,6 +2660,126 @@ static int cmdTest(id viewContext) {
         [viewContext save:nil];
     }
 
+    // Test: shared/CRDT note paragraph coalescing (issue #48)
+    // Shared notes back their attributed string with a CRDT (ICTTMergeableString)
+    // which produces many small TTStyle fragments — each with a distinct UUID —
+    // even within a single logical paragraph.  Before the fix, noteToParaModel
+    // used UUID change as the paragraph boundary, so a paragraph like
+    // "Hello World" split across three style fragments was emitted as three
+    // separate paragraphs ("Hello", " ", "World") and rendered as one
+    // character/token per line.  The fix splits paragraphs on the actual \n
+    // character, so multi-fragment paragraphs coalesce correctly.
+    fprintf(stderr, "Test: shared/CRDT paragraph coalescing (#48)...\n");
+    {
+        NSString *fragTitle = @"__crdt_frag_test__";
+        // Two body paragraphs, each split into multiple style-3 fragments
+        // (each fragment's TTStyle alloc'd separately so it gets its own UUID).
+        NSArray *p1Frags = @[@"Hello", @" ", @"World"];
+        NSArray *p2Frags = @[@"Foo", @" ", @"Bar"];
+        NSString *p1Joined = [p1Frags componentsJoinedByString:@""];
+        NSString *p2Joined = [p2Frags componentsJoinedByString:@""];
+        NSString *fragContent = [NSString stringWithFormat:@"%@\n%@\n%@", fragTitle, p1Joined, p2Joined];
+
+        id fragNote = ((id (*)(id, SEL, id))objc_msgSend)(ICNoteClass, sel_registerName("newEmptyNoteInFolder:"), testFolder);
+        id fragDoc = ((id (*)(id, SEL))objc_msgSend)(fragNote, sel_registerName("document"));
+        id fragMs = ((id (*)(id, SEL))objc_msgSend)(fragDoc, sel_registerName("mergeableString"));
+        ((void (*)(id, SEL))objc_msgSend)(fragNote, sel_registerName("beginEditing"));
+        ((void (*)(id, SEL, id, NSUInteger))objc_msgSend)(fragMs, sel_registerName("insertString:atIndex:"), fragContent, 0);
+
+        // Title style (covers title text + the trailing \n)
+        id sTitle = [[ICTTParagraphStyleClass alloc] init];
+        ((void (*)(id, SEL, NSUInteger))objc_msgSend)(sTitle, sel_registerName("setStyle:"), 0);
+        ((void (*)(id, SEL, id, NSRange))objc_msgSend)(fragMs, sel_registerName("setAttributes:range:"),
+            @{@"TTStyle": sTitle}, NSMakeRange(0, fragTitle.length + 1));
+
+        // Body para 1: each fragment gets its own ICTTParagraphStyle / UUID
+        NSUInteger fragOff = fragTitle.length + 1;
+        for (NSString *frag in p1Frags) {
+            id s = [[ICTTParagraphStyleClass alloc] init];
+            ((void (*)(id, SEL, NSUInteger))objc_msgSend)(s, sel_registerName("setStyle:"), 3);
+            ((void (*)(id, SEL, id, NSRange))objc_msgSend)(fragMs, sel_registerName("setAttributes:range:"),
+                @{@"TTStyle": s}, NSMakeRange(fragOff, frag.length));
+            fragOff += frag.length;
+        }
+        // Newline between paragraphs gets its own style (yet another UUID)
+        {
+            id sNL = [[ICTTParagraphStyleClass alloc] init];
+            ((void (*)(id, SEL, NSUInteger))objc_msgSend)(sNL, sel_registerName("setStyle:"), 3);
+            ((void (*)(id, SEL, id, NSRange))objc_msgSend)(fragMs, sel_registerName("setAttributes:range:"),
+                @{@"TTStyle": sNL}, NSMakeRange(fragOff, 1));
+            fragOff += 1;
+        }
+        // Body para 2: same multi-fragment treatment
+        for (NSString *frag in p2Frags) {
+            id s = [[ICTTParagraphStyleClass alloc] init];
+            ((void (*)(id, SEL, NSUInteger))objc_msgSend)(s, sel_registerName("setStyle:"), 3);
+            ((void (*)(id, SEL, id, NSRange))objc_msgSend)(fragMs, sel_registerName("setAttributes:range:"),
+                @{@"TTStyle": s}, NSMakeRange(fragOff, frag.length));
+            fragOff += frag.length;
+        }
+
+        ((void (*)(id, SEL, NSUInteger, NSRange, NSInteger))objc_msgSend)(
+            fragNote, sel_registerName("edited:range:changeInLength:"), 1,
+            NSMakeRange(0, fragContent.length), fragContent.length);
+        ((void (*)(id, SEL))objc_msgSend)(fragNote, sel_registerName("endEditing"));
+        ((void (*)(id, SEL))objc_msgSend)(fragNote, sel_registerName("saveNoteData"));
+        [viewContext save:nil];
+
+        NSArray *fragModel = noteToParaModel(fragNote);
+        // Strip leading empty paragraphs (canonical leading \n) — same filter
+        // pattern used by noteToMarkdownString.
+        NSMutableArray *fragFiltered = [NSMutableArray array];
+        BOOL fragFc = NO;
+        for (NSDictionary *p in fragModel) {
+            if (!fragFc && [p[@"text"] length] == 0) continue;
+            fragFc = YES;
+            [fragFiltered addObject:p];
+        }
+
+        BOOL fragOk = YES;
+        if (fragFiltered.count != 3) {
+            fragOk = NO;
+            fprintf(stderr, "  FAIL: paragraph count: expected 3, got %lu\n",
+                (unsigned long)fragFiltered.count);
+            for (NSUInteger pi = 0; pi < fragFiltered.count; pi++) {
+                fprintf(stderr, "    [%lu] style=%ld text='%s'\n",
+                    (unsigned long)pi,
+                    (long)[fragFiltered[pi][@"style"] integerValue],
+                    [fragFiltered[pi][@"text"] UTF8String]);
+            }
+        } else {
+            if (![fragFiltered[0][@"text"] isEqualToString:fragTitle]) {
+                fragOk = NO;
+                fprintf(stderr, "  FAIL: title text: '%s' (expected '%s')\n",
+                    [fragFiltered[0][@"text"] UTF8String], [fragTitle UTF8String]);
+            }
+            if (![fragFiltered[1][@"text"] isEqualToString:p1Joined]) {
+                fragOk = NO;
+                fprintf(stderr, "  FAIL: body para 1: '%s' (expected '%s')\n",
+                    [fragFiltered[1][@"text"] UTF8String], [p1Joined UTF8String]);
+            }
+            if (![fragFiltered[2][@"text"] isEqualToString:p2Joined]) {
+                fragOk = NO;
+                fprintf(stderr, "  FAIL: body para 2: '%s' (expected '%s')\n",
+                    [fragFiltered[2][@"text"] UTF8String], [p2Joined UTF8String]);
+            }
+        }
+
+        // Also verify the markdown output isn't fragmented across many lines
+        NSString *fragMd = paraModelToMarkdown(fragFiltered);
+        if (![fragMd containsString:p1Joined]) {
+            fragOk = NO;
+            fprintf(stderr, "  FAIL: markdown missing '%s', got:\n%s\n",
+                [p1Joined UTF8String], [fragMd UTF8String]);
+        }
+
+        if (fragOk) { fprintf(stderr, "  PASS\n"); passed++; }
+        else { failed++; }
+
+        deleteNote(fragNote, viewContext);
+        [viewContext save:nil];
+    }
+
     // Test: markdown code block round-trip
     fprintf(stderr, "Test: markdown code block round-trip...\n");
     {


### PR DESCRIPTION
Closes #48.

## Root cause

\`noteToParaModel\` detected paragraph boundaries by **TTStyle UUID change**. That works for canonical Apple Notes (one TTStyle UUID per paragraph) but breaks for shared/collaborated notes backed by \`ICTTMergeableString\` (a CRDT). In CRDT notes every edit creates a new style fragment with a new UUID even within one logical paragraph, so titles like _"Laura EI access code biweekly reports"_ were emitted character-by-character.

## Fix

Switch the boundary detection to the **actual newline character** (U+000A) in the text — the semantic truth for both canonical and CRDT notes. Within a paragraph, the first contributing chunk supplies paragraph-level attributes (style, indent, todoDone, uuid) and subsequent chunks contribute inline runs.

Also adds an **export-only** post-process that doubles single-\`\n\` paragraph separators into blank lines so paragraphs render correctly in CommonMark/GitHub markdown viewers. The \`read-markdown\` / \`write-markdown\` round-trip output format is unchanged.

## Test plan

- [x] All 128 existing tests still pass.
- [x] New \`shared/CRDT paragraph coalescing (#48)\` test added — simulates CRDT fragmentation by applying multiple \`ICTTParagraphStyle\` instances (each with its own UUID) to ranges within one paragraph. Without the fix the test emits 7-8 paragraphs; with the fix it correctly emits 3.
- [x] Verified on the real-world reproducing notes (\`Laura EI access code biweekly reports\`, \`June 10 midwife notes\`) — titles and body content now coalesce correctly.
- [x] Full export of 10,218 notes runs in ~14s with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)