### PR TITLE
Add --metadata flag for optional export frontmatter fields

### DIFF
--- a/notekit-handwritten.m
+++ b/notekit-handwritten.m
@@ -2154,7 +2154,7 @@ static NSString *yamlScalar(NSString *s) {
 
 // Export every (non-locked) note as one file with YAML frontmatter.
 // Mirrors folder hierarchy under outputPath. Locked notes are skipped.
-static int cmdExport(id viewContext, NSString *outputPath, NSString *folderFilter, NSString *format, BOOL preserveRoundTrip) {
+static int cmdExport(id viewContext, NSString *outputPath, NSString *folderFilter, NSString *format, BOOL preserveRoundTrip, NSSet *metadataFields) {
     if (!outputPath || outputPath.length == 0) errorExit(@"--output required");
     if (!format) format = @"md";
     BOOL isMarkdown = NO;
@@ -2231,6 +2231,69 @@ static int cmdExport(id viewContext, NSString *outputPath, NSString *folderFilte
         }
         if (createdDate)  [content appendFormat:@"created: %@\n",  dateToISO(createdDate)];
         if (modifiedDate) [content appendFormat:@"modified: %@\n", dateToISO(modifiedDate)];
+
+        // Optional metadata fields (additive; controlled by --metadata flag).
+        if ([metadataFields containsObject:@"id"]) {
+            @try {
+                NSString *noteID = ((id (*)(id, SEL))objc_msgSend)(note, sel_registerName("identifier"));
+                if (noteID && noteID.length > 0) [content appendFormat:@"id: %@\n", yamlScalar(noteID)];
+            } @catch (NSException *e) {}
+        }
+        if ([metadataFields containsObject:@"account"]) {
+            @try {
+                id folder = ((id (*)(id, SEL))objc_msgSend)(note, sel_registerName("folder"));
+                id account = folder ? ((id (*)(id, SEL))objc_msgSend)(folder, sel_registerName("account")) : nil;
+                NSString *acctName = nil;
+                if (account) {
+                    @try { acctName = ((id (*)(id, SEL))objc_msgSend)(account, sel_registerName("name")); } @catch (NSException *e) {}
+                }
+                if (acctName && acctName.length > 0) [content appendFormat:@"account: %@\n", yamlScalar(acctName)];
+            } @catch (NSException *e) {}
+        }
+        if ([metadataFields containsObject:@"pinned"]) {
+            BOOL v = NO;
+            @try { v = ((BOOL (*)(id, SEL))objc_msgSend)(note, sel_registerName("isPinned")); } @catch (NSException *e) {}
+            [content appendFormat:@"pinned: %@\n", v ? @"true" : @"false"];
+        }
+        if ([metadataFields containsObject:@"locked"]) {
+            BOOL v = NO;
+            @try { v = ((BOOL (*)(id, SEL))objc_msgSend)(note, sel_registerName("isLocked")); } @catch (NSException *e) {}
+            [content appendFormat:@"locked: %@\n", v ? @"true" : @"false"];
+        }
+        if ([metadataFields containsObject:@"hasChecklist"]) {
+            BOOL v = NO;
+            @try { v = ((BOOL (*)(id, SEL))objc_msgSend)(note, sel_registerName("hasChecklist")); } @catch (NSException *e) {}
+            [content appendFormat:@"hasChecklist: %@\n", v ? @"true" : @"false"];
+        }
+        if ([metadataFields containsObject:@"hasTags"]) {
+            BOOL v = NO;
+            @try { v = ((BOOL (*)(id, SEL))objc_msgSend)(note, sel_registerName("hasTags")); } @catch (NSException *e) {}
+            [content appendFormat:@"hasTags: %@\n", v ? @"true" : @"false"];
+        }
+        if ([metadataFields containsObject:@"attachmentCount"]) {
+            @try {
+                id atts = ((id (*)(id, SEL))objc_msgSend)(note, sel_registerName("attachments"));
+                NSUInteger count = atts ? [atts count] : 0;
+                [content appendFormat:@"attachmentCount: %lu\n", (unsigned long)count];
+            } @catch (NSException *e) {}
+        }
+        if ([metadataFields containsObject:@"snippet"]) {
+            @try {
+                NSString *snippet = ((id (*)(id, SEL))objc_msgSend)(note, sel_registerName("snippet"));
+                if (snippet && snippet.length > 0) [content appendFormat:@"snippet: %@\n", yamlScalar(snippet)];
+            } @catch (NSException *e) {}
+        }
+        if ([metadataFields containsObject:@"url"]) {
+            @try {
+                Class ICAppURLUtilities = NSClassFromString(@"ICAppURLUtilities");
+                if (ICAppURLUtilities) {
+                    NSURL *appURL = ((id (*)(id, SEL, id))objc_msgSend)(
+                        ICAppURLUtilities, sel_registerName("appURLForNote:"), note);
+                    if (appURL) [content appendFormat:@"url: %@\n", yamlScalar([appURL absoluteString])];
+                }
+            } @catch (NSException *e) {}
+        }
+
         [content appendString:@"---\n\n"];
 
         if (isMarkdown) {
@@ -2328,10 +2391,13 @@ static void usage(void) {
     fprintf(stderr, "\n");
     fprintf(stderr, "Bulk export:\n");
     fprintf(stderr, "  notekit export --output <dir> [--folder <name>] [--format md|txt]\n");
-    fprintf(stderr, "                 [--preserve-round-trip]\n");
+    fprintf(stderr, "                 [--metadata <fields>] [--preserve-round-trip]\n");
     fprintf(stderr, "      Writes one file per note with YAML frontmatter (title, folder, created,\n");
-    fprintf(stderr, "      modified). Mirrors folder hierarchy as subdirectories. Locked notes are\n");
-    fprintf(stderr, "      skipped with a warning. Default format is md.\n");
+    fprintf(stderr, "      modified always included). Mirrors folder hierarchy as subdirectories.\n");
+    fprintf(stderr, "      Locked notes are skipped with a warning. Default format is md.\n");
+    fprintf(stderr, "      --metadata adds optional frontmatter fields (comma-separated).\n");
+    fprintf(stderr, "        Available: id, account, pinned, locked, hasChecklist, hasTags,\n");
+    fprintf(stderr, "        attachmentCount, snippet, url.\n");
     fprintf(stderr, "      By default, soft line breaks become markdown hard breaks and defensive\n");
     fprintf(stderr,  "      backslash escaping is removed for clean human-readable output.\n");
     fprintf(stderr, "      Use --preserve-round-trip to keep <br> tags and char escapes so the\n");

--- a/notekit.m
+++ b/notekit.m
@@ -314,7 +314,27 @@ int main(int argc, const char *argv[]) {
             NSString *outputPath = opts[@"output"];
             if (!outputPath || outputPath.length == 0) { fprintf(stderr, "Error: --output required\n"); usage(); return 1; }
             BOOL preserveRoundTrip = [opts[@"preserve-round-trip"] isEqualToString:@"true"];
-            return cmdExport(viewContext, outputPath, folderName, opts[@"format"], preserveRoundTrip);
+            NSSet *metadataFields = nil;
+            NSString *metadataArg = opts[@"metadata"];
+            if (metadataArg && metadataArg.length > 0) {
+                NSSet *valid = [NSSet setWithArray:@[
+                    @"id", @"account", @"pinned", @"locked",
+                    @"hasChecklist", @"hasTags", @"attachmentCount",
+                    @"snippet", @"url"
+                ]];
+                NSMutableSet *requested = [NSMutableSet set];
+                for (NSString *part in [metadataArg componentsSeparatedByString:@","]) {
+                    NSString *trimmed = [part stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                    if (trimmed.length == 0) continue;
+                    if (![valid containsObject:trimmed]) {
+                        fprintf(stderr, "Error: unknown metadata field '%s'. Valid: id, account, pinned, locked, hasChecklist, hasTags, attachmentCount, snippet, url\n", [trimmed UTF8String]);
+                        return 1;
+                    }
+                    [requested addObject:trimmed];
+                }
+                metadataFields = requested;
+            }
+            return cmdExport(viewContext, outputPath, folderName, opts[@"format"], preserveRoundTrip, metadataFields);
 
         } else if ([command isEqualToString:@"test"]) {
             return cmdTest(viewContext);


### PR DESCRIPTION
## Summary

Adds a comma-separated \`--metadata\` flag that opts in additional YAML frontmatter fields beyond the always-on defaults (\`title\`, \`folder\`, \`created\`, \`modified\`).

\`\`\`
notekit export --output <dir> [--metadata <fields>] ...
\`\`\`

## Available fields

| Field | Type | Source |
|---|---|---|
| \`id\` | string | Stable Apple Notes identifier |
| \`account\` | string | iCloud / On My Mac etc. |
| \`pinned\` | bool | \`isPinned\` |
| \`locked\` | bool | \`isLocked\` |
| \`hasChecklist\` | bool | \`hasChecklist\` |
| \`hasTags\` | bool | \`hasTags\` |
| \`attachmentCount\` | int | \`attachments.count\` |
| \`snippet\` | string | Notes' auto-generated preview |
| \`url\` | string | \`applenotes://\` deep link |

Unknown field names cause an error rather than silent drop. Each optional field is wrapped in \`@try/@catch\` for safety against selectors that may not exist on every Apple Notes version.

## Example

\`\`\`yaml
---
title: "Dentist questions"
folder: "Logs Archive"
created: 2025-07-17T17:01:45Z
modified: 2025-07-17T18:46:17Z
id: "D9137865-6702-4FC7-9168-F7AFA191E282"
account: "iCloud"
pinned: false
locked: false
hasChecklist: true
hasTags: false
attachmentCount: 1
snippet: "Which medications"
url: "applenotes://showNote?identifier=D9137865-6702-4FC7-9168-F7AFA191E282"
---
\`\`\`

## Test plan

- [x] All 132 existing tests pass.
- [x] Smoke-tested all 9 fields in combination on a real note (216-note folder).
- [x] Subset (\`--metadata id\`) emits only \`id\`.
- [x] Invalid field name (\`--metadata id,nonexistent\`) errors out with a helpful message.
- [x] Defaults preserved when \`--metadata\` is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)