### PR TITLE
Fix version drift: derive embedded version from build (#55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CC = clang
-CFLAGS = -framework Foundation -framework CoreData -framework AppKit -lobjc -O2
+# Version embedded in the binary. The Homebrew formula passes VERSION=#{version}
+# (the release tag); local builds fall back to the latest git tag, then "dev".
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)
+CFLAGS = -framework Foundation -framework CoreData -framework AppKit -lobjc -O2 -DNOTEKIT_VERSION='"$(VERSION)"'
 INFO_PLIST = Info.plist
 BUNDLE_ID = com.jtennant.notekit-cli
 INFO_PLIST_FLAGS = -Wl,-sectcreate,__TEXT,__info_plist,$(INFO_PLIST)

--- a/notekit-version-check.m
+++ b/notekit-version-check.m
@@ -1,94 +1,16 @@
-// Version checks and background Homebrew upgrades.
+// Version string and background Homebrew upgrades.
 
-static NSString * const NotekitCurrentVersion = @"0.5.78";
-static NSString * const NotekitFormulaURL = @"https://raw.githubusercontent.com/johnmatthewtennant/homebrew-tap/master/Formula/notekit-cli.rb";
+// The version is injected at build time via -DNOTEKIT_VERSION (passed by the
+// Homebrew formula as VERSION=#{version}). The "dev" fallback applies only to
+// ad-hoc local builds, keeping the embedded version in lockstep with the
+// release tag instead of a hand-edited constant.
+#ifndef NOTEKIT_VERSION
+#define NOTEKIT_VERSION "dev"
+#endif
+static NSString * const NotekitCurrentVersion = @NOTEKIT_VERSION;
 static NSString * const NotekitFormulaTap = @"johnmatthewtennant/tap/notekit-cli";
 static NSString * const NotekitFormulaName = @"notekit-cli";
 static NSString * const NotekitCommandName = @"notekit";
-
-static NSString *parseFormulaVersion(NSString *formulaBody) {
-    __block NSString *version = nil;
-    [formulaBody enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
-        NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        if ([trimmed hasPrefix:@"version \""]) {
-            NSString *rest = [trimmed substringFromIndex:[@"version \"" length]];
-            NSRange closing = [rest rangeOfString:@"\""];
-            if (closing.location != NSNotFound) {
-                version = [rest substringToIndex:closing.location];
-                *stop = YES;
-            }
-        }
-
-        NSRange tagRange = [trimmed rangeOfString:@"archive/refs/tags/v"];
-        if (tagRange.location != NSNotFound) {
-            NSUInteger start = tagRange.location + tagRange.length;
-            NSString *rest = [trimmed substringFromIndex:start];
-            NSRange end = [rest rangeOfString:@".tar.gz"];
-            if (end.location != NSNotFound) {
-                version = [rest substringToIndex:end.location];
-                *stop = YES;
-            }
-        }
-    }];
-    return version;
-}
-
-static NSString *latestKnownVersion(NSTimeInterval timeout) {
-    NSURL *url = [NSURL URLWithString:NotekitFormulaURL];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request setTimeoutInterval:timeout];
-
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    __block NSData *data = nil;
-    __block NSURLResponse *response = nil;
-    __block NSError *error = nil;
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
-        dataTaskWithRequest:request
-        completionHandler:^(NSData *taskData, NSURLResponse *taskResponse, NSError *taskError) {
-            data = taskData;
-            response = taskResponse;
-            error = taskError;
-            dispatch_semaphore_signal(sema);
-        }];
-    [task resume];
-
-    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)((timeout + 1) * NSEC_PER_SEC));
-    if (dispatch_semaphore_wait(sema, deadline) != 0) {
-        [task cancel];
-        return nil;
-    }
-
-    if (error || !data) return nil;
-    if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
-        [(NSHTTPURLResponse *)response statusCode] != 200) {
-        return nil;
-    }
-
-    NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    if (!body) return nil;
-    return parseFormulaVersion(body);
-}
-
-static BOOL isOutdated(NSString *current, NSString *latest) {
-    NSArray *currentParts = [current componentsSeparatedByString:@"."];
-    NSArray *latestParts = [latest componentsSeparatedByString:@"."];
-    NSUInteger maxCount = MAX([currentParts count], [latestParts count]);
-
-    for (NSUInteger i = 0; i < maxCount; i++) {
-        NSInteger c = i < [currentParts count] ? [currentParts[i] integerValue] : 0;
-        NSInteger l = i < [latestParts count] ? [latestParts[i] integerValue] : 0;
-        if (l > c) return YES;
-        if (l < c) return NO;
-    }
-    return NO;
-}
-
-static NSString *outdatedWarning(NSString *latest) {
-    if (!latest || !isOutdated(NotekitCurrentVersion, latest)) return nil;
-    return [NSString stringWithFormat:
-        @"notekit %@ is outdated. Latest: %@. Run: brew upgrade %@",
-        NotekitCurrentVersion, latest, NotekitFormulaTap];
-}
 
 static BOOL shouldAttemptUpgrade(NSDate *now, NSDate *lastAttempt) {
     if (!lastAttempt) return YES;
@@ -137,11 +59,9 @@ static void attemptBackgroundUpgrade(void) {
 }
 
 static int cmdVersion(BOOL skipCheck) {
+    // Background auto-upgrade (attemptBackgroundUpgrade) keeps brew installs
+    // current, so there is no separate outdated-version network check.
+    (void)skipCheck;
     printf("notekit %s\n", [NotekitCurrentVersion UTF8String]);
-    if (!skipCheck) {
-        NSString *latest = latestKnownVersion(2);
-        NSString *warning = outdatedWarning(latest);
-        if (warning) fprintf(stderr, "%s\n", [warning UTF8String]);
-    }
     return 0;
 }


### PR DESCRIPTION
Fixes #55.

## Problem
`NotekitCurrentVersion` was a hand-maintained constant at risk of drifting from the release tag — the same bug that already bit reminderkit (#38). A tag bump without updating the constant would make `notekit version` print a false outdated warning.

## Fix
- **Inject the version at build time** via `-DNOTEKIT_VERSION`. The Homebrew formula passes `VERSION=#{version}` (the release tag), so the embedded string is always exactly the tag. Local builds fall back to the latest git tag, then `dev`. Single source of truth, no hand-editing.
- **Remove the outdated-version network check** (`parseFormulaVersion`/`latestKnownVersion`/`isOutdated`/`outdatedWarning`). Background auto-upgrade already keeps brew installs current within 24h, and the warning only ever appeared on `notekit version`.

## Companion change
The required Homebrew formula change has landed in `johnmatthewtennant/homebrew-tap` (`b736ff8`): `system "make", "VERSION=#{version}"`.

## Testing
- `make VERSION=0.5.82 && ./notekit version` → `notekit 0.5.82`
- `make && ./notekit version` → latest local git tag
- `./notekit test` → 144 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)